### PR TITLE
role_changing

### DIFF
--- a/commands/dungeons/lfg.js
+++ b/commands/dungeons/lfg.js
@@ -249,13 +249,7 @@ module.exports = {
 
                 confirmCollector.on("collect", async (i) => {
                     if (i.customId === "confirm") {
-                        sendEmbed(
-                            mainObject,
-                            currentChannel,
-                            dungeonToRun,
-                            dungeonDifficulty,
-                            updatedDungeonCompositionList
-                        );
+                        sendEmbed(mainObject, currentChannel, updatedDungeonCompositionList);
 
                         await compositionConfirmation.deleteReply();
                     }

--- a/utils/dungeonLogic.js
+++ b/utils/dungeonLogic.js
@@ -32,6 +32,33 @@ function getEligibleComposition(mainObject) {
     return selectComposition;
 }
 
+async function processDungeonEmbed(
+    i,
+    rolesToTag,
+    dungeon,
+    difficulty,
+    mainObject,
+    groupUtilityCollector
+) {
+    const newDungeonObject = getDungeonObject(dungeon, difficulty, mainObject);
+    if (newDungeonObject.status === "full") {
+        groupUtilityCollector.stop("full");
+        await i.update({
+            content: ``,
+            embeds: [newDungeonObject],
+            components: [],
+        });
+    } else {
+        const newEmbedButtonRow = getDungeonButtonRow(mainObject);
+
+        await i.update({
+            content: `${rolesToTag}`,
+            embeds: [newDungeonObject],
+            components: [newEmbedButtonRow],
+        });
+    }
+}
+
 function getDungeonObject(dungeon, difficulty, mainObject) {
     const listedAs = mainObject.embedData.listedAs;
     const interactionUser = mainObject.interactionUser.userId;
@@ -93,4 +120,9 @@ function getDungeonButtonRow(mainObject) {
     return embedButtonRow;
 }
 
-module.exports = { getEligibleComposition, getDungeonObject, getDungeonButtonRow };
+module.exports = {
+    getEligibleComposition,
+    processDungeonEmbed,
+    getDungeonObject,
+    getDungeonButtonRow,
+};

--- a/utils/sendEmbed.js
+++ b/utils/sendEmbed.js
@@ -3,15 +3,21 @@ const { parseRolesToTag, generateListedAsString, addUserToRole } = require("./ut
 const { dungeonInstanceTable } = require("./loadDb");
 const { processDungeonEmbed, getDungeonObject, getDungeonButtonRow } = require("./dungeonLogic");
 
-async function sendEmbed(mainObject, channel, dungeon, difficulty, requiredCompositionList) {
+async function sendEmbed(mainObject, channel, requiredCompositionList) {
+    const { dungeonName, dungeonDifficulty } = mainObject.embedData;
+
     // Get the roles to tag
-    const rolesToTag = parseRolesToTag(difficulty, requiredCompositionList, channel.guild.id);
+    const rolesToTag = parseRolesToTag(
+        dungeonDifficulty,
+        requiredCompositionList,
+        channel.guild.id
+    );
 
     // Update the listedAs field in the mainObject
-    mainObject.embedData.listedAs = generateListedAsString(dungeon, difficulty);
+    mainObject.embedData.listedAs = generateListedAsString(dungeonName, dungeonDifficulty);
 
     // Create the object that is used to send to the embed
-    const dungeonObject = getDungeonObject(dungeon, difficulty, mainObject);
+    const dungeonObject = getDungeonObject(dungeonName, dungeonDifficulty, mainObject);
 
     // Create the button row for the embed
     const embedButtonRow = getDungeonButtonRow(mainObject);
@@ -34,8 +40,8 @@ async function sendEmbed(mainObject, channel, dungeon, difficulty, requiredCompo
             processDungeonEmbed(
                 i,
                 rolesToTag,
-                dungeon,
-                difficulty,
+                dungeonName,
+                dungeonDifficulty,
                 mainObject,
                 groupUtilityCollector
             );
@@ -44,8 +50,8 @@ async function sendEmbed(mainObject, channel, dungeon, difficulty, requiredCompo
             processDungeonEmbed(
                 i,
                 rolesToTag,
-                dungeon,
-                difficulty,
+                dungeonName,
+                dungeonDifficulty,
                 mainObject,
                 groupUtilityCollector
             );
@@ -54,8 +60,8 @@ async function sendEmbed(mainObject, channel, dungeon, difficulty, requiredCompo
             processDungeonEmbed(
                 i,
                 rolesToTag,
-                dungeon,
-                difficulty,
+                dungeonName,
+                dungeonDifficulty,
                 mainObject,
                 groupUtilityCollector
             );

--- a/utils/sendEmbed.js
+++ b/utils/sendEmbed.js
@@ -30,7 +30,7 @@ async function sendEmbed(mainObject, channel, requiredCompositionList) {
 
     const groupUtilityCollector = sentEmbed.createMessageComponentCollector({
         componentType: ComponentType.Button,
-        // time: 30_000, // ! Change this back from 10s to 30 minutes
+        time: 1_800_000, // Wait 30 minutes to form a group before timing out
     });
 
     groupUtilityCollector.on("collect", async (i) => {
@@ -69,7 +69,6 @@ async function sendEmbed(mainObject, channel, requiredCompositionList) {
     });
 
     groupUtilityCollector.on("end", async (collected, reason) => {
-        console.log(reason);
         if (reason === "time") {
             const timedOutObject = {
                 title: "LFG TIMED OUT (30 mins) ⏰",
@@ -86,6 +85,7 @@ async function sendEmbed(mainObject, channel, requiredCompositionList) {
                 console.error("Error editing message:", err);
             }
         } else if (reason === "full") {
+            // Send the finished dungeon data to the database
             try {
                 await dungeonInstanceTable.create({
                     dungeon_name: mainObject.embedData.dungeonName,

--- a/utils/utilFunctions.js
+++ b/utils/utilFunctions.js
@@ -63,41 +63,34 @@ function parseRolesToTag(difficulty, requiredComposition, guildId) {
     return roleMentions;
 }
 
+// Disable the button if the role is full
+function updateButtonState(mainObject, roleName) {
+    const role = mainObject.roles[roleName];
+    if (roleName === "Tank" || roleName === "Healer") {
+        role.disabled = role.spots.length >= 1;
+    } else {
+        role.disabled = role.spots.length >= 3;
+    }
+}
+
 function addUserToRole(userId, mainObject, newRole) {
     if (userId === mainObject.interactionUser.userId) {
-        mainObject.roles.Tank.spots.push(mainObject.embedData.filledSpot);
+        mainObject.roles[newRole].spots.push(mainObject.embedData.filledSpot);
+        updateButtonState(mainObject, newRole);
     } else {
-        // Use slice(0, 3) to select the first three roles
         const firstThreeRoles = Object.entries(mainObject.roles).slice(0, 3);
 
-        // Check if the user already is part of the group
         for (let [roleName, roleData] of firstThreeRoles) {
             if (roleData.spots.includes(userId)) {
-                // Remove the user from the previous role
-                const userIndex = roleData.spots.indexOf(userId);
-                if (userIndex > -1) {
-                    roleData.spots.splice(userIndex, 1);
-
-                    // If the previous role button was disabled, enable it
-                    if (roleName === "Tank" || roleName === "Healer") {
-                        mainObject.roles[roleName].disabled = false;
-                    } else if (roleName === "DPS" && roleData.spots.length < 3) {
-                        mainObject.roles[roleName].disabled = false;
-                    }
-                }
+                roleData.spots.splice(roleData.spots.indexOf(userId), 1);
+                // Enable the button if the role is no longer full
+                updateButtonState(mainObject, roleName);
             }
         }
-        // Add the user to the new role
+
         mainObject.roles[newRole].spots.push(userId);
-
-        if (mainObject.roles[newRole].spots.length === 3) {
-            mainObject.roles[newRole].disabled = true;
-        } else if (newRole === "Tank" || newRole === "Healer") {
-            mainObject.roles[newRole].disabled = true;
-        }
+        updateButtonState(mainObject, newRole);
     }
-
-    return;
 }
 
 module.exports = {

--- a/utils/utilFunctions.js
+++ b/utils/utilFunctions.js
@@ -97,13 +97,6 @@ function addUserToRole(userId, mainObject, newRole) {
         }
     }
 
-    // TODO: Think about if we need this or if a full group is enough
-    // Counting the total number of filled spots
-    // let filledSpotsCount = 0;
-    // for (let roleData of Object.values(mainObject.roles).slice(0, 3)) {
-    //     filledSpotsCount += roleData.spots.length;
-    // }
-
     return;
 }
 

--- a/utils/utilFunctions.js
+++ b/utils/utilFunctions.js
@@ -64,7 +64,7 @@ function parseRolesToTag(difficulty, requiredComposition, guildId) {
 }
 
 function addUserToRole(userId, mainObject, newRole) {
-    if (userId === "mainObject.interactionUser.userId") {
+    if (userId === mainObject.interactionUser.userId) {
         mainObject.roles.Tank.spots.push(mainObject.embedData.filledSpot);
     } else {
         // Use slice(0, 3) to select the first three roles


### PR DESCRIPTION
We're introducing the ability for `non-interaction` users to change their roles.
This is good because if they accidentally apply as the incorrect role they can correct it. 

Haven't introduced this for the group leader _yet_ for a couple of reasons:
1. When the group leader clicks on a role button, they can fill the role spots (if someone joins in-game that's not currently on Discord or is a non-NoP user)
2. Keeping the amount of available buttons to a minimum. This would require another button or another pop-up where the `interaction user` would need to confirm their choice every time. 

If we _really__ need this, an alternative is we add a ⚙ icon where they receive an ephemeral menu where they can fill roles and change their own role. 