### PR TITLE
Error & status processing

### DIFF
--- a/commands/dungeons/lfg.js
+++ b/commands/dungeons/lfg.js
@@ -12,6 +12,7 @@ const { dungeonList, wowWords } = require("../../utils/loadJson");
 const { generatePassphrase, isDPSRole } = require("../../utils/utilFunctions");
 const { getEligibleComposition } = require("../../utils/dungeonLogic");
 const { sendEmbed } = require("../../utils/sendEmbed");
+const { interactionStatusTable } = require("../../utils/loadDb");
 const { processError } = require("../../utils/errorHandling");
 
 module.exports = {
@@ -58,6 +59,7 @@ module.exports = {
                 spotIcons: [],
                 filledSpot: "~~Filled Spot~~",
             },
+            interactionId: interaction.id,
             interactionUser: {
                 userId: `<@${interaction.user.id}>`,
                 userChosenRole: "",
@@ -253,6 +255,13 @@ module.exports = {
                         sendEmbed(mainObject, currentChannel, updatedDungeonCompositionList);
 
                         await compositionConfirmation.deleteReply();
+
+                        // Send the created dungeon status to the database
+                        await interactionStatusTable.create({
+                            interaction_id: interaction.id,
+                            interaction_user: interaction.user.id,
+                            interaction_status: "created",
+                        });
                     }
                     if (i.customId === "cancel") {
                         await interaction.editReply({
@@ -260,6 +269,12 @@ module.exports = {
                                 "Cancelled. Please try the command again if you wish to create a group.",
                             ephemeral: true,
                             components: [],
+                        });
+
+                        interactionStatusTable.create({
+                            interaction_id: interaction.id,
+                            interaction_user: interaction.user.id,
+                            interaction_status: "cancelled",
                         });
                     }
                 });

--- a/commands/dungeons/lfg.js
+++ b/commands/dungeons/lfg.js
@@ -12,6 +12,7 @@ const { dungeonList, wowWords } = require("../../utils/loadJson");
 const { generatePassphrase, isDPSRole } = require("../../utils/utilFunctions");
 const { getEligibleComposition } = require("../../utils/dungeonLogic");
 const { sendEmbed } = require("../../utils/sendEmbed");
+const { processError } = require("../../utils/errorHandling");
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -254,34 +255,16 @@ module.exports = {
                         await compositionConfirmation.deleteReply();
                     }
                     if (i.customId === "cancel") {
-                        await interaction.followUp({
+                        await interaction.editReply({
                             content:
                                 "Cancelled. Please try the command again if you wish to create a group.",
                             ephemeral: true,
+                            components: [],
                         });
                     }
                 });
             } catch (e) {
-                // Check if the error is due to a timeout
-                if (
-                    e.name.includes("InteractionCollectorError") &&
-                    e.message.includes("Collector received no interactions")
-                ) {
-                    // Inform user about the timeout
-                    await interaction.editReply({
-                        content:
-                            "You did not respond in time (60s).\nPlease try the command again if you wish to create a group.",
-                        ephemeral: true,
-                        component: [],
-                    });
-                } else {
-                    // Optionally send a message to the user if the error is different
-                    await interaction.editReply({
-                        content: "An error occurred while processing your request.",
-                        ephemeral: true,
-                        component: [],
-                    });
-                }
+                processError(e, interaction);
             }
         }
         runCommandLogic();

--- a/commands/utility/history.js
+++ b/commands/utility/history.js
@@ -5,8 +5,10 @@ const {
     StringSelectMenuOptionBuilder,
 } = require("discord.js");
 const { Op } = require("sequelize");
+
 const { dungeonInstanceTable } = require("../../utils/loadDb.js");
 const { getPastDungeonObject } = require("../../utils/historyLogic.js");
+const { processError } = require("../../utils/errorHandling.js");
 
 const timeOptions = {
     year: "numeric",
@@ -88,26 +90,7 @@ module.exports = {
                 components: [],
             });
         } catch (e) {
-            // Check if the error is due to a timeout
-            if (
-                e.name.includes("InteractionCollectorError") &&
-                e.message.includes("Collector received no interactions")
-            ) {
-                // Inform user about the timeout
-                await interaction.editReply({
-                    content:
-                        "You did not respond in time (60s).\nPlease try the command again if you wish to view past dungeons.",
-                    ephemeral: true,
-                    components: [], // Need to send empty components to remove the dropdown
-                });
-            } else {
-                // Optionally send a message to the user if the error is different
-                await interaction.editReply({
-                    content: "An error occurred while processing your request.",
-                    ephemeral: true,
-                    components: [],
-                });
-            }
+            processError(e, interaction);
         }
     },
 };

--- a/utils/errorHandling.js
+++ b/utils/errorHandling.js
@@ -1,9 +1,15 @@
+const { errorTable } = require("./loadDb");
+
 async function processError(error, interaction) {
+    let errorName = "";
     // Check if the error is due to a timeout
     if (
         error.name.includes("InteractionCollectorError") &&
         error.message.includes("Collector received no interactions")
     ) {
+        // Simpler name for a standard timeout error
+        errorName = "timeout";
+
         // Inform user about the timeout
         await interaction.editReply({
             content:
@@ -19,4 +25,13 @@ async function processError(error, interaction) {
             components: [],
         });
     }
+
+    // Send the error to the database
+    await errorTable.create({
+        error_name: errorName || error.name,
+        error_message: error.message,
+        user_id: interaction.user.id,
+    });
 }
+
+module.exports = { processError };

--- a/utils/errorHandling.js
+++ b/utils/errorHandling.js
@@ -1,0 +1,22 @@
+async function processError(error, interaction) {
+    // Check if the error is due to a timeout
+    if (
+        error.name.includes("InteractionCollectorError") &&
+        error.message.includes("Collector received no interactions")
+    ) {
+        // Inform user about the timeout
+        await interaction.editReply({
+            content:
+                "You did not respond in time (60s).\nPlease try the command again if you wish to create a group.",
+            ephemeral: true,
+            components: [],
+        });
+    } else {
+        // Optionally send a message to the user if the error is different
+        await interaction.editReply({
+            content: "An error occurred while processing your request.",
+            ephemeral: true,
+            components: [],
+        });
+    }
+}

--- a/utils/loadDb.js
+++ b/utils/loadDb.js
@@ -52,8 +52,48 @@ const dungeonInstanceTable = sequelize.define("dungeoninstance", {
     },
 });
 
+const errorTable = sequelize.define("errors", {
+    error_id: {
+        type: Sequelize.INTEGER,
+        primaryKey: true,
+        autoIncrement: true,
+    },
+    error_name: {
+        type: Sequelize.STRING,
+        allowNull: false,
+    },
+    error_message: {
+        type: Sequelize.STRING,
+        allowNull: false,
+    },
+    user_id: {
+        type: Sequelize.STRING,
+        allowNull: false,
+    },
+});
+
+const interactionStatusTable = sequelize.define("interaction_status", {
+    status_id: {
+        type: Sequelize.INTEGER,
+        primaryKey: true,
+        autoIncrement: true,
+    },
+    interaction_id: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+    },
+    interaction_user: {
+        type: Sequelize.STRING,
+        allowNull: false,
+    },
+    interaction_status: {
+        type: Sequelize.STRING,
+        allowNull: false,
+    },
+});
+
 function syncTables() {
     sequelize.sync({ force: false });
 }
 
-module.exports = { syncTables, dungeonInstanceTable };
+module.exports = { syncTables, dungeonInstanceTable, errorTable, interactionStatusTable };

--- a/utils/sendEmbed.js
+++ b/utils/sendEmbed.js
@@ -1,6 +1,6 @@
 const { ComponentType } = require("discord.js");
 const { parseRolesToTag, generateListedAsString, addUserToRole } = require("./utilFunctions");
-const { dungeonInstanceTable } = require("./loadDb");
+const { dungeonInstanceTable, interactionStatusTable } = require("./loadDb");
 const { processDungeonEmbed, getDungeonObject, getDungeonButtonRow } = require("./dungeonLogic");
 
 async function sendEmbed(mainObject, channel, requiredCompositionList) {
@@ -81,6 +81,12 @@ async function sendEmbed(mainObject, channel, requiredCompositionList) {
                     embeds: [timedOutObject],
                     components: [],
                 });
+
+                // Update the interaction status to "timed out"
+                await interactionStatusTable.update(
+                    { interaction_status: "timed out" },
+                    { where: { interaction_id: mainObject.interactionId } }
+                );
             } catch (err) {
                 console.error("Error editing message:", err);
             }
@@ -98,6 +104,12 @@ async function sendEmbed(mainObject, channel, requiredCompositionList) {
                     dps2: mainObject.roles.DPS.spots[1],
                     dps3: mainObject.roles.DPS.spots[2],
                 });
+
+                // Update the interaction status to "finished"
+                await interactionStatusTable.update(
+                    { interaction_status: "finished" },
+                    { where: { interaction_id: mainObject.interactionId } }
+                );
             } catch (err) {
                 console.error("Error writing to table:", err);
             }


### PR DESCRIPTION
We're passing errors & status updates to the respective tables so we can keep track of what kind of errors we're receiving and also we can track how many dungeons are timing out or how many `finished` dungeons are being created. 

This way, we can measure performance and interaction with the bot and also pick up any issues users are having and also have a constant feedback loop for the current process.