### PR TITLE
composition_passphrase_changes

### DIFF
--- a/commands/dungeons/lfg.js
+++ b/commands/dungeons/lfg.js
@@ -218,8 +218,6 @@ module.exports = {
                                 return role.startsWith("DPS") ? "DPS" : role;
                             });
 
-                            const dungeonComposition = updatedDungeonCompositionList.join(", ");
-
                             if (i.customId === "confirm") {
                                 sendEmbed(mainObject, currentChannel, updatedDungeonCompositionList);
 

--- a/commands/dungeons/lfg.js
+++ b/commands/dungeons/lfg.js
@@ -1,9 +1,9 @@
 const {
-  ActionRowBuilder,
-  SlashCommandBuilder,
-  StringSelectMenuBuilder,
-  StringSelectMenuOptionBuilder,
-  ButtonBuilder,
+    ActionRowBuilder,
+    SlashCommandBuilder,
+    StringSelectMenuBuilder,
+    StringSelectMenuOptionBuilder,
+    ButtonBuilder,
 } = require("discord.js");
 
 const { dungeonList } = require("../../utils/loadJson");
@@ -12,297 +12,242 @@ const { isDPSRole } = require("../../utils/utilFunctions");
 const { getEligibleComposition } = require("../../utils/dungeonLogic");
 const { sendEmbed } = require("../../utils/sendEmbed");
 const { interactionStatusTable } = require("../../utils/loadDb");
-const {
-  processError,
-  createStatusEmbed,
-} = require("../../utils/errorHandling");
+const { processError, createStatusEmbed } = require("../../utils/errorHandling");
 
 module.exports = {
-  data: new SlashCommandBuilder()
-    .setName("lfg")
-    .setDescription("Post a message to find a group for your key."),
-  async execute(interaction) {
-    const mainObject = getMainObject(interaction);
+    data: new SlashCommandBuilder().setName("lfg").setDescription("Post a message to find a group for your key."),
+    async execute(interaction) {
+        const mainObject = getMainObject(interaction);
 
-    // Timeout for the interaction collector
-    const timeout = 60_000;
+        // Timeout for the interaction collector
+        const timeout = 60_000;
 
-    const selectDungeon = new StringSelectMenuBuilder()
-      .setCustomId("dungeons")
-      .setPlaceholder("Select a dungeon")
-      .setMinValues(1)
-      .setMaxValues(1)
-      .addOptions(
-        dungeonList.map((dungeon) =>
-          new StringSelectMenuOptionBuilder()
-            .setLabel(dungeon)
-            .setValue(dungeon)
-        )
-      );
-
-    // Parse key levels from the channel name
-    const currentChannel = interaction.channel;
-    const channelName = currentChannel.name;
-    const channelNameSplit = channelName.split("-");
-    const lowerDifficultyRange = parseInt(channelNameSplit[1].replace("m", ""));
-    const upperDifficultyRange =
-      lowerDifficultyRange === 21
-        ? 30
-        : parseInt(channelNameSplit[2].replace("m", ""));
-
-    // Make a list with dungeon difficulty ranges like +2, +3, +4
-    const dungeonDifficultyRanges = [];
-
-    for (let i = lowerDifficultyRange; i <= upperDifficultyRange; i++) {
-      dungeonDifficultyRanges.push(i);
-    }
-
-    const selectDifficulty = new StringSelectMenuBuilder()
-      .setCustomId("difficulty")
-      .setPlaceholder("Select a difficulty")
-      .setMinValues(1)
-      .setMaxValues(1)
-      .addOptions(
-        dungeonDifficultyRanges.map((range) =>
-          new StringSelectMenuOptionBuilder()
-            .setLabel(`+${range}`)
-            .setValue(`${range}`)
-        )
-      );
-
-    const selectTimedCompleted = new StringSelectMenuBuilder()
-      .setCustomId("timedCompleted")
-      .setPlaceholder("Is the goal to time or complete the dungeon?")
-      .setMinValues(1)
-      .setMaxValues(1)
-      .addOptions(
-        new StringSelectMenuOptionBuilder().setLabel("Timed").setValue("Timed"),
-        new StringSelectMenuOptionBuilder()
-          .setLabel("Completed")
-          .setValue("Completed")
-      );
-
-    const selectUserRole = new StringSelectMenuBuilder()
-      .setCustomId("userRole")
-      .setPlaceholder("Select your role")
-      .setMinValues(1)
-      .setMaxValues(1)
-      .addOptions(
-        new StringSelectMenuOptionBuilder()
-          .setLabel("Tank")
-          .setValue("Tank")
-          .setEmoji(mainObject.roles.Tank.emoji),
-        new StringSelectMenuOptionBuilder()
-          .setLabel("Healer")
-          .setValue("Healer")
-          .setEmoji(mainObject.roles.Healer.emoji),
-        new StringSelectMenuOptionBuilder()
-          .setLabel("DPS")
-          .setValue("DPS")
-          .setEmoji(mainObject.roles.DPS.emoji)
-      );
-
-    const confirmSuccess = new ButtonBuilder()
-      .setLabel("Create Group")
-      .setCustomId("confirm")
-      .setStyle(3);
-
-    const confirmCancel = new ButtonBuilder()
-      .setLabel("Cancel")
-      .setCustomId("cancel")
-      .setStyle(4);
-
-    const dungeonRow = new ActionRowBuilder().addComponents(selectDungeon);
-    const difficultyRow = new ActionRowBuilder().addComponents(
-      selectDifficulty
-    );
-    const timedCompletedRow = new ActionRowBuilder().addComponents(
-      selectTimedCompleted
-    );
-    const userRoleRow = new ActionRowBuilder().addComponents(selectUserRole);
-
-    const confirmCancelRow = new ActionRowBuilder().addComponents(
-      confirmSuccess,
-      confirmCancel
-    );
-
-    const dungeonResponse = await interaction.reply({
-      ephemeral: true,
-      components: [dungeonRow],
-    });
-
-    const userFilter = (i) => i.user.id === interaction.user.id;
-
-    async function runCommandLogic() {
-      try {
-        const dungeonConfirmation = await dungeonResponse.awaitMessageComponent(
-          {
-            filter: userFilter,
-            time: timeout,
-          }
-        );
-
-        const dungeonToRun = dungeonConfirmation.values[0];
-        mainObject.embedData.dungeonName = dungeonToRun;
-
-        const difficultyResponse = await dungeonConfirmation.update({
-          content: `Dungeon: ${dungeonToRun}.`,
-          components: [difficultyRow],
-        });
-
-        const difficultyConfirmation =
-          await difficultyResponse.awaitMessageComponent({
-            filter: userFilter,
-            time: timeout,
-          });
-
-        const dungeonDifficulty = difficultyConfirmation.values[0];
-        mainObject.embedData.dungeonDifficulty = `+${dungeonDifficulty}`;
-
-        const timedCompletedResponse = await difficultyConfirmation.update({
-          content: `Dungeon: ${dungeonToRun}\nDifficulty: +${dungeonDifficulty}`,
-          components: [timedCompletedRow],
-        });
-
-        const timedCompletedConfirmation =
-          await timedCompletedResponse.awaitMessageComponent({
-            filter: userFilter,
-            time: timeout,
-          });
-
-        const timedOrCompleted = timedCompletedConfirmation.values[0];
-        mainObject.embedData.timedOrCompleted = timedOrCompleted;
-
-        const userRoleResponse = await timedCompletedConfirmation.update({
-          content: `Dungeon: ${dungeonToRun}\nDifficulty: +${dungeonDifficulty}\nTimed/Completed: ${timedOrCompleted}`,
-          components: [userRoleRow],
-        });
-
-        const userRoleConfirmation =
-          await userRoleResponse.awaitMessageComponent({
-            filter: userFilter,
-            time: timeout,
-          });
-
-        const userChosenRole = userRoleConfirmation.values[0];
-        // Add the user's chosen role to the main object so it's easily accessible
-        mainObject.interactionUser.userChosenRole = userChosenRole;
-
-        // Calculate the eligible composition based on the user's chosen role
-        const selectComposition = getEligibleComposition(mainObject);
-
-        const teamCompositionRow = new ActionRowBuilder().addComponents(
-          selectComposition
-        );
-
-        const compositionResponse = await userRoleConfirmation.update({
-          content: `Dungeon: ${dungeonToRun}\nDifficulty: +${dungeonDifficulty}\nTimed/Completed: ${timedOrCompleted}\nYour role: ${userChosenRole}\nRequired roles:`,
-          components: [teamCompositionRow, confirmCancelRow],
-        });
-
-        // Temporary storage for dropdown values
-        let dungeonCompositionList = null;
-
-        // Create a collector for both dropdown and button interactions
-        const confirmCollector =
-          compositionResponse.createMessageComponentCollector({
-            filter: userFilter,
-            time: timeout,
-          });
-
-        confirmCollector.on("collect", async (i) => {
-          if (i.isStringSelectMenu()) {
-            dungeonCompositionList = i.values;
-
-            // This is required if user selects the wrong roles and wants to change them
-            await i.deferUpdate();
-          } else if (i.customId === "confirm") {
-            // Inform the user if they didn't select any roles
-            if (!dungeonCompositionList) {
-              // If the user didn't select any roles display a warning message
-              await compositionResponse.edit({
-                content: `Dungeon: ${dungeonToRun}\nDifficulty: +${dungeonDifficulty}\nTimed/Completed: ${timedOrCompleted}\nYour role: ${userChosenRole}\nRequired roles:\n**Please select at least one role!**`,
-                components: [teamCompositionRow, confirmCancelRow],
-              });
-
-              i.deferUpdate();
-            } else {
-              // Add the user to the main object
-              mainObject.roles[userChosenRole].spots.push(
-                mainObject.interactionUser.userId
-              );
-
-              // Pull the filled spot from the main object
-              const filledSpot = mainObject.embedData.filledSpot;
-
-              for (const role in mainObject.roles) {
-                if (!dungeonCompositionList.includes(role)) {
-                  // Add filled members to the spots, except for the user's chosen role
-                  if (role !== userChosenRole) {
-                    if (isDPSRole(role)) {
-                      if (mainObject.roles["DPS"].spots.length < 3) {
-                        mainObject.roles["DPS"].spots.push(filledSpot);
-                      }
-                    } else {
-                      mainObject.roles[role].spots.push(filledSpot);
-                    }
-                  }
-
-                  if (
-                    isDPSRole(role) &
-                    (mainObject.roles["DPS"].spots.length >= 3)
-                  ) {
-                    mainObject.roles["DPS"].disabled = true;
-                  } else if (!isDPSRole(role)) {
-                    mainObject.roles[role].disabled = true;
-                  }
-                }
-              }
-
-              const updatedDungeonCompositionList = dungeonCompositionList.map(
-                (role) => {
-                  return role.startsWith("DPS") ? "DPS" : role;
-                }
-              );
-
-              const dungeonComposition =
-                updatedDungeonCompositionList.join(", ");
-
-              if (i.customId === "confirm") {
-                sendEmbed(
-                  mainObject,
-                  currentChannel,
-                  updatedDungeonCompositionList
-                );
-
-                // Delete the interaction confirmation messages due to the ephemeral flag
-                await interaction.deleteReply();
-
-                // Send the created dungeon status to the database
-                await interactionStatusTable.create({
-                  interaction_id: interaction.id,
-                  interaction_user: interaction.user.id,
-                  interaction_status: "created",
-                });
-              }
-            }
-          } else if (i.customId === "cancel") {
-            await createStatusEmbed(
-              "LFG cancelled by the user.",
-              compositionResponse
+        const selectDungeon = new StringSelectMenuBuilder()
+            .setCustomId("dungeons")
+            .setPlaceholder("Select a dungeon")
+            .setMinValues(1)
+            .setMaxValues(1)
+            .addOptions(
+                dungeonList.map((dungeon) => new StringSelectMenuOptionBuilder().setLabel(dungeon).setValue(dungeon))
             );
 
-            interactionStatusTable.create({
-              interaction_id: interaction.id,
-              interaction_user: interaction.user.id,
-              interaction_status: "cancelled",
-            });
-          }
+        // Parse key levels from the channel name
+        const currentChannel = interaction.channel;
+        const channelName = currentChannel.name;
+        const channelNameSplit = channelName.split("-");
+        const lowerDifficultyRange = parseInt(channelNameSplit[1].replace("m", ""));
+        const upperDifficultyRange = lowerDifficultyRange === 21 ? 30 : parseInt(channelNameSplit[2].replace("m", ""));
+
+        // Make a list with dungeon difficulty ranges like +2, +3, +4
+        const dungeonDifficultyRanges = [];
+
+        for (let i = lowerDifficultyRange; i <= upperDifficultyRange; i++) {
+            dungeonDifficultyRanges.push(i);
+        }
+
+        const selectDifficulty = new StringSelectMenuBuilder()
+            .setCustomId("difficulty")
+            .setPlaceholder("Select a difficulty")
+            .setMinValues(1)
+            .setMaxValues(1)
+            .addOptions(
+                dungeonDifficultyRanges.map((range) =>
+                    new StringSelectMenuOptionBuilder().setLabel(`+${range}`).setValue(`${range}`)
+                )
+            );
+
+        const selectTimedCompleted = new StringSelectMenuBuilder()
+            .setCustomId("timedCompleted")
+            .setPlaceholder("Is the goal to time or complete the dungeon?")
+            .setMinValues(1)
+            .setMaxValues(1)
+            .addOptions(
+                new StringSelectMenuOptionBuilder().setLabel("Timed").setValue("Timed"),
+                new StringSelectMenuOptionBuilder().setLabel("Completed").setValue("Completed")
+            );
+
+        const selectUserRole = new StringSelectMenuBuilder()
+            .setCustomId("userRole")
+            .setPlaceholder("Select your role")
+            .setMinValues(1)
+            .setMaxValues(1)
+            .addOptions(
+                new StringSelectMenuOptionBuilder()
+                    .setLabel("Tank")
+                    .setValue("Tank")
+                    .setEmoji(mainObject.roles.Tank.emoji),
+                new StringSelectMenuOptionBuilder()
+                    .setLabel("Healer")
+                    .setValue("Healer")
+                    .setEmoji(mainObject.roles.Healer.emoji),
+                new StringSelectMenuOptionBuilder().setLabel("DPS").setValue("DPS").setEmoji(mainObject.roles.DPS.emoji)
+            );
+
+        const confirmSuccess = new ButtonBuilder().setLabel("Create Group").setCustomId("confirm").setStyle(3);
+
+        const confirmCancel = new ButtonBuilder().setLabel("Cancel").setCustomId("cancel").setStyle(4);
+
+        const dungeonRow = new ActionRowBuilder().addComponents(selectDungeon);
+        const difficultyRow = new ActionRowBuilder().addComponents(selectDifficulty);
+        const timedCompletedRow = new ActionRowBuilder().addComponents(selectTimedCompleted);
+        const userRoleRow = new ActionRowBuilder().addComponents(selectUserRole);
+
+        const confirmCancelRow = new ActionRowBuilder().addComponents(confirmSuccess, confirmCancel);
+
+        const dungeonResponse = await interaction.reply({
+            ephemeral: true,
+            components: [dungeonRow],
         });
-      } catch (e) {
-        processError(e, interaction);
-      }
-    }
-    runCommandLogic();
-  },
+
+        const userFilter = (i) => i.user.id === interaction.user.id;
+
+        async function runCommandLogic() {
+            try {
+                const dungeonConfirmation = await dungeonResponse.awaitMessageComponent({
+                    filter: userFilter,
+                    time: timeout,
+                });
+
+                const dungeonToRun = dungeonConfirmation.values[0];
+                mainObject.embedData.dungeonName = dungeonToRun;
+
+                const difficultyResponse = await dungeonConfirmation.update({
+                    content: `Dungeon: ${dungeonToRun}.`,
+                    components: [difficultyRow],
+                });
+
+                const difficultyConfirmation = await difficultyResponse.awaitMessageComponent({
+                    filter: userFilter,
+                    time: timeout,
+                });
+
+                const dungeonDifficulty = difficultyConfirmation.values[0];
+                mainObject.embedData.dungeonDifficulty = `+${dungeonDifficulty}`;
+
+                const timedCompletedResponse = await difficultyConfirmation.update({
+                    content: `Dungeon: ${dungeonToRun}\nDifficulty: +${dungeonDifficulty}`,
+                    components: [timedCompletedRow],
+                });
+
+                const timedCompletedConfirmation = await timedCompletedResponse.awaitMessageComponent({
+                    filter: userFilter,
+                    time: timeout,
+                });
+
+                const timedOrCompleted = timedCompletedConfirmation.values[0];
+                mainObject.embedData.timedOrCompleted = timedOrCompleted;
+
+                const userRoleResponse = await timedCompletedConfirmation.update({
+                    content: `Dungeon: ${dungeonToRun}\nDifficulty: +${dungeonDifficulty}\nTimed/Completed: ${timedOrCompleted}`,
+                    components: [userRoleRow],
+                });
+
+                const userRoleConfirmation = await userRoleResponse.awaitMessageComponent({
+                    filter: userFilter,
+                    time: timeout,
+                });
+
+                const userChosenRole = userRoleConfirmation.values[0];
+                // Add the user's chosen role to the main object so it's easily accessible
+                mainObject.interactionUser.userChosenRole = userChosenRole;
+
+                // Calculate the eligible composition based on the user's chosen role
+                const selectComposition = getEligibleComposition(mainObject);
+
+                const teamCompositionRow = new ActionRowBuilder().addComponents(selectComposition);
+
+                const compositionResponse = await userRoleConfirmation.update({
+                    content: `Dungeon: ${dungeonToRun}\nDifficulty: +${dungeonDifficulty}\nTimed/Completed: ${timedOrCompleted}\nYour role: ${userChosenRole}\nRequired roles:`,
+                    components: [teamCompositionRow, confirmCancelRow],
+                });
+
+                // Temporary storage for dropdown values
+                let dungeonCompositionList = null;
+
+                // Create a collector for both dropdown and button interactions
+                const confirmCollector = compositionResponse.createMessageComponentCollector({
+                    filter: userFilter,
+                    time: timeout,
+                });
+
+                confirmCollector.on("collect", async (i) => {
+                    if (i.isStringSelectMenu()) {
+                        dungeonCompositionList = i.values;
+
+                        // This is required if user selects the wrong roles and wants to change them
+                        await i.deferUpdate();
+                    } else if (i.customId === "confirm") {
+                        // Inform the user if they didn't select any roles
+                        if (!dungeonCompositionList) {
+                            // If the user didn't select any roles display a warning message
+                            await compositionResponse.edit({
+                                content: `Dungeon: ${dungeonToRun}\nDifficulty: +${dungeonDifficulty}\nTimed/Completed: ${timedOrCompleted}\nYour role: ${userChosenRole}\nRequired roles:\n**Please select at least one role!**`,
+                                components: [teamCompositionRow, confirmCancelRow],
+                            });
+
+                            i.deferUpdate();
+                        } else {
+                            // Add the user to the main object
+                            mainObject.roles[userChosenRole].spots.push(mainObject.interactionUser.userId);
+
+                            // Pull the filled spot from the main object
+                            const filledSpot = mainObject.embedData.filledSpot;
+
+                            for (const role in mainObject.roles) {
+                                if (!dungeonCompositionList.includes(role)) {
+                                    // Add filled members to the spots, except for the user's chosen role
+                                    if (role !== userChosenRole) {
+                                        if (isDPSRole(role)) {
+                                            if (mainObject.roles["DPS"].spots.length < 3) {
+                                                mainObject.roles["DPS"].spots.push(filledSpot);
+                                            }
+                                        } else {
+                                            mainObject.roles[role].spots.push(filledSpot);
+                                        }
+                                    }
+
+                                    if (isDPSRole(role) & (mainObject.roles["DPS"].spots.length >= 3)) {
+                                        mainObject.roles["DPS"].disabled = true;
+                                    } else if (!isDPSRole(role)) {
+                                        mainObject.roles[role].disabled = true;
+                                    }
+                                }
+                            }
+
+                            const updatedDungeonCompositionList = dungeonCompositionList.map((role) => {
+                                return role.startsWith("DPS") ? "DPS" : role;
+                            });
+
+                            const dungeonComposition = updatedDungeonCompositionList.join(", ");
+
+                            if (i.customId === "confirm") {
+                                sendEmbed(mainObject, currentChannel, updatedDungeonCompositionList);
+
+                                // Delete the interaction confirmation messages due to the ephemeral flag
+                                await interaction.deleteReply();
+
+                                // Send the created dungeon status to the database
+                                await interactionStatusTable.create({
+                                    interaction_id: interaction.id,
+                                    interaction_user: interaction.user.id,
+                                    interaction_status: "created",
+                                });
+                            }
+                        }
+                    } else if (i.customId === "cancel") {
+                        await createStatusEmbed("LFG cancelled by the user.", compositionResponse);
+
+                        interactionStatusTable.create({
+                            interaction_id: interaction.id,
+                            interaction_user: interaction.user.id,
+                            interaction_status: "cancelled",
+                        });
+                    }
+                });
+            } catch (e) {
+                processError(e, interaction);
+            }
+        }
+        runCommandLogic();
+    },
 };

--- a/commands/dungeons/lfg.js
+++ b/commands/dungeons/lfg.js
@@ -219,7 +219,12 @@ module.exports = {
                             });
 
                             if (i.customId === "confirm") {
-                                sendEmbed(mainObject, currentChannel, updatedDungeonCompositionList);
+                                await sendEmbed(mainObject, currentChannel, updatedDungeonCompositionList);
+
+                                await i.reply({
+                                    content: `The passphrase for the dungeon is: ${mainObject.utils.passphrase.phrase}`,
+                                    ephemeral: true,
+                                });
 
                                 // Delete the interaction confirmation messages due to the ephemeral flag
                                 await interaction.deleteReply();

--- a/commands/dungeons/lfg.js
+++ b/commands/dungeons/lfg.js
@@ -62,6 +62,16 @@ module.exports = {
                 )
             );
 
+        const selectTimedCompleted = new StringSelectMenuBuilder()
+            .setCustomId("timedCompleted")
+            .setPlaceholder("Is the goal to time or complete the dungeon?")
+            .setMinValues(1)
+            .setMaxValues(1)
+            .addOptions(
+                new StringSelectMenuOptionBuilder().setLabel("Timed").setValue("Timed"),
+                new StringSelectMenuOptionBuilder().setLabel("Completed").setValue("Completed")
+            );
+
         const selectUserRole = new StringSelectMenuBuilder()
             .setCustomId("userRole")
             .setPlaceholder("Select your role")
@@ -99,6 +109,7 @@ module.exports = {
 
         const dungeonRow = new ActionRowBuilder().addComponents(selectDungeon);
         const difficultyRow = new ActionRowBuilder().addComponents(selectDifficulty);
+        const timedCompletedRow = new ActionRowBuilder().addComponents(selectTimedCompleted);
         const userRoleRow = new ActionRowBuilder().addComponents(selectUserRole);
 
         const confirmCancelRow = new ActionRowBuilder().addComponents(
@@ -136,7 +147,21 @@ module.exports = {
                 const dungeonDifficulty = difficultyConfirmation.values[0];
                 mainObject.embedData.dungeonDifficulty = `+${dungeonDifficulty}`;
 
-                const userRoleResponse = await difficultyConfirmation.update({
+                const timedCompletedResponse = await difficultyConfirmation.update({
+                    content: `Dungeon: ${dungeonToRun}\nDifficulty: +${dungeonDifficulty}`,
+                    components: [timedCompletedRow],
+                });
+
+                const timedCompletedConfirmation =
+                    await timedCompletedResponse.awaitMessageComponent({
+                        filter: userFilter,
+                        time: timeout,
+                    });
+
+                const timedOrCompleted = timedCompletedConfirmation.values[0];
+                mainObject.embedData.timedOrCompleted = timedOrCompleted;
+
+                const userRoleResponse = await timedCompletedConfirmation.update({
                     content: `Dungeon: ${dungeonToRun}\nDifficulty: +${dungeonDifficulty}`,
                     components: [userRoleRow],
                 });

--- a/utils/dungeonLogic.js
+++ b/utils/dungeonLogic.js
@@ -2,6 +2,7 @@ const {
     ActionRowBuilder,
     StringSelectMenuBuilder,
     StringSelectMenuOptionBuilder,
+    ButtonStyle,
 } = require("discord.js");
 const { dungeonData } = require("./loadJson");
 const { createButton } = require("./discordFunctions");
@@ -42,7 +43,7 @@ async function processDungeonEmbed(
 ) {
     const newDungeonObject = getDungeonObject(dungeon, difficulty, mainObject);
     if (newDungeonObject.status === "full") {
-        groupUtilityCollector.stop("full");
+        groupUtilityCollector.stop("finished");
         await i.update({
             content: ``,
             embeds: [newDungeonObject],
@@ -111,10 +112,18 @@ function getDungeonButtonRow(mainObject) {
     const addHealerToGroup = createButton(healer, healer.emoji, healer.style, healer.disabled);
     const addDpsToGroup = createButton(dps, dps.emoji, dps.style, dps.disabled);
 
+    const cancelGroupButton = createButton({
+        customId: "cancelGroup",
+        emoji: "❌",
+        style: ButtonStyle.Secondary,
+        disabled: false,
+    });
+
     const embedButtonRow = new ActionRowBuilder().addComponents(
         addTankToGroup,
         addHealerToGroup,
-        addDpsToGroup
+        addDpsToGroup,
+        cancelGroupButton
     );
 
     return embedButtonRow;

--- a/utils/dungeonLogic.js
+++ b/utils/dungeonLogic.js
@@ -1,9 +1,4 @@
-const {
-    ActionRowBuilder,
-    StringSelectMenuBuilder,
-    StringSelectMenuOptionBuilder,
-    ButtonStyle,
-} = require("discord.js");
+const { ActionRowBuilder, StringSelectMenuBuilder, StringSelectMenuOptionBuilder, ButtonStyle } = require("discord.js");
 const { dungeonData } = require("./loadJson");
 const { createButton } = require("./discordFunctions");
 const { generateRoleIcons } = require("./utilFunctions");
@@ -33,14 +28,7 @@ function getEligibleComposition(mainObject) {
     return selectComposition;
 }
 
-async function processDungeonEmbed(
-    i,
-    rolesToTag,
-    dungeon,
-    difficulty,
-    mainObject,
-    groupUtilityCollector
-) {
+async function processDungeonEmbed(i, rolesToTag, dungeon, difficulty, mainObject, groupUtilityCollector) {
     const newDungeonObject = getDungeonObject(dungeon, difficulty, mainObject);
     if (newDungeonObject.status === "full") {
         groupUtilityCollector.stop("finished");
@@ -94,6 +82,8 @@ function getDungeonObject(dungeon, difficulty, mainObject) {
             { name: `${healerEmoji} Healer`, value: `${healerSpot || "\u200b"}`, inline: false },
             { name: `${dpsEmoji} DPS`, value: `${dpsSpots || "\u200b"}`, inline: false },
         ],
+        // TODO: Add an array with general tips and a random tip is chosen
+        footer: { text: "Tip: Remember to click on the key to get the passphrase for your note!" },
         status: "",
     };
     if (roleIcons.length > 4) {

--- a/utils/dungeonLogic.js
+++ b/utils/dungeonLogic.js
@@ -63,6 +63,7 @@ async function processDungeonEmbed(
 function getDungeonObject(dungeon, difficulty, mainObject) {
     const listedAs = mainObject.embedData.listedAs;
     const interactionUser = mainObject.interactionUser.userId;
+    const timedCompleted = mainObject.embedData.timedOrCompleted;
 
     const tank = mainObject.roles.Tank;
     const healer = mainObject.roles.Healer;
@@ -87,7 +88,7 @@ function getDungeonObject(dungeon, difficulty, mainObject) {
         fields: [
             { name: `Created by`, value: `${interactionUser}`, inline: false },
             { name: `Listed as`, value: ` ${listedAs}`, inline: true },
-            { name: "Passphrase", value: `${mainObject.utils.passphrase.phrase}`, inline: true },
+            { name: "Timed/Completed", value: `${timedCompleted}`, inline: true },
             { name: `${tankEmoji} Tank `, value: `${tankSpot || "\u200b"}`, inline: false },
 
             { name: `${healerEmoji} Healer`, value: `${healerSpot || "\u200b"}`, inline: false },
@@ -112,6 +113,13 @@ function getDungeonButtonRow(mainObject) {
     const addHealerToGroup = createButton(healer, healer.emoji, healer.style, healer.disabled);
     const addDpsToGroup = createButton(dps, dps.emoji, dps.style, dps.disabled);
 
+    const getPassphraseButton = createButton({
+        customId: "getPassphrase",
+        emoji: "🔑",
+        style: ButtonStyle.Secondary,
+        disabled: false,
+    });
+
     const cancelGroupButton = createButton({
         customId: "cancelGroup",
         emoji: "❌",
@@ -123,6 +131,7 @@ function getDungeonButtonRow(mainObject) {
         addTankToGroup,
         addHealerToGroup,
         addDpsToGroup,
+        getPassphraseButton,
         cancelGroupButton
     );
 

--- a/utils/errorHandling.js
+++ b/utils/errorHandling.js
@@ -20,7 +20,8 @@ async function processError(error, interaction) {
     } else {
         // Optionally send a message to the user if the error is different
         await interaction.editReply({
-            content: "An error occurred while processing your request.",
+            content:
+                "An error occurred while processing your request.\nIf this was a mistake, please ping <@268396301928890369>",
             ephemeral: true,
             components: [],
         });
@@ -34,4 +35,23 @@ async function processError(error, interaction) {
     });
 }
 
-module.exports = { processError };
+async function processSendEmbedError(error, reason, userId) {
+    // Send the error to the database
+    await errorTable.create({
+        error_name: reason,
+        error_message: error.message,
+        user_id: userId,
+    });
+}
+
+async function createStatusEmbed(statusMessage, embedMessage) {
+    const contactMessage = `\nPlease try /lfg again if you wish to create a group.\n\nIf this was a mistake, please ping <@268396301928890369>`;
+
+    await embedMessage.edit({
+        content: statusMessage + contactMessage,
+        embeds: [],
+        components: [],
+    });
+}
+
+module.exports = { processError, processSendEmbedError, createStatusEmbed };

--- a/utils/errorHandling.js
+++ b/utils/errorHandling.js
@@ -1,6 +1,7 @@
 const { errorTable } = require("./loadDb");
 
 async function processError(error, interaction) {
+    console.log(error);
     let errorName = "";
     // Check if the error is due to a timeout
     if (

--- a/utils/getMainObject.js
+++ b/utils/getMainObject.js
@@ -1,0 +1,60 @@
+const { ButtonStyle } = require("discord.js");
+const { generatePassphrase } = require("./utilFunctions");
+const { wowWords } = require("./loadJson.js");
+
+function getMainObject(interaction) {
+    const mainObject = {
+        roles: {
+            Tank: {
+                spots: [],
+                style: ButtonStyle.Secondary,
+                disabled: false,
+                customId: "Tank",
+                emoji: `<:tankrole:1181327150708686848>`,
+            },
+            Healer: {
+                spots: [],
+                style: ButtonStyle.Secondary,
+                disabled: false,
+                customId: "Healer",
+                emoji: `<:healrole:1181327153749561364>`,
+            },
+            DPS: {
+                spots: [],
+                style: ButtonStyle.Secondary,
+                disabled: false,
+                customId: "DPS",
+                emoji: `<:dpsrole:1181327148624117870>`,
+            },
+            DPS2: {
+                customId: "DPS2",
+                emoji: `<:dpsrole:1181327148624117870>`,
+            },
+            DPS3: {
+                customId: "DPS3",
+                emoji: `<:dpsrole:1181327148624117870>`,
+            },
+        },
+        embedData: {
+            dungeonName: "",
+            dungeonDifficulty: "",
+            listedAs: "",
+            spotIcons: [],
+            filledSpot: "~~Filled Spot~~",
+        },
+        interactionId: interaction.id,
+        interactionUser: {
+            userId: `<@${interaction.user.id}>`,
+            userChosenRole: "",
+        },
+        utils: {
+            passphrase: {
+                phrase: generatePassphrase(wowWords),
+            },
+        },
+    };
+
+    return mainObject;
+}
+
+module.exports = { getMainObject };

--- a/utils/getMainObject.js
+++ b/utils/getMainObject.js
@@ -38,6 +38,7 @@ function getMainObject(interaction) {
         embedData: {
             dungeonName: "",
             dungeonDifficulty: "",
+            timedOrCompleted: "",
             listedAs: "",
             spotIcons: [],
             filledSpot: "~~Filled Spot~~",

--- a/utils/historyLogic.js
+++ b/utils/historyLogic.js
@@ -2,6 +2,8 @@ function getPastDungeonObject(dungeonInstance) {
     const dungeonValues = dungeonInstance.dataValues;
     const dungeon = dungeonValues.dungeon_name;
     const difficulty = dungeonValues.dungeon_difficulty;
+    const timed_completed = dungeonValues.timed_completed;
+    const passphrase = dungeonValues.passphrase;
     const interactionUser = dungeonValues.interaction_user;
     const tankSpot = dungeonValues.tank;
     const healerSpot = dungeonValues.healer;
@@ -19,6 +21,8 @@ function getPastDungeonObject(dungeonInstance) {
         title: `${dungeon} ${difficulty}`,
         fields: [
             { name: `Created by`, value: `${interactionUser}`, inline: false },
+            { name: `Passphrase`, value: `${passphrase}`, inline: true },
+            { name: `Timed/Completed`, value: `${timed_completed}`, inline: true },
             { name: `${tankEmoji} Tank `, value: `${tankSpot || "\u200b"}`, inline: false },
 
             { name: `${healerEmoji} Healer`, value: `${healerSpot || "\u200b"}`, inline: false },

--- a/utils/loadDb.js
+++ b/utils/loadDb.js
@@ -22,6 +22,14 @@ const dungeonInstanceTable = sequelize.define("dungeoninstance", {
         type: Sequelize.STRING,
         allowNull: false,
     },
+    timed_completed: {
+        type: Sequelize.STRING,
+        allowNull: false,
+    },
+    passphrase: {
+        type: Sequelize.STRING,
+        allowNull: false,
+    },
     interaction_user: {
         type: Sequelize.STRING,
         allowNull: false,

--- a/utils/sendEmbed.js
+++ b/utils/sendEmbed.js
@@ -2,9 +2,11 @@ const { ComponentType } = require("discord.js");
 const { parseRolesToTag, generateListedAsString, addUserToRole } = require("./utilFunctions");
 const { dungeonInstanceTable, interactionStatusTable } = require("./loadDb");
 const { processDungeonEmbed, getDungeonObject, getDungeonButtonRow } = require("./dungeonLogic");
+const { processEmbedError, createStatusEmbed } = require("./errorHandling");
 
 async function sendEmbed(mainObject, channel, requiredCompositionList) {
     const { dungeonName, dungeonDifficulty } = mainObject.embedData;
+    const interactionUserId = mainObject.interactionUser.userId;
 
     // Get the roles to tag
     const rolesToTag = parseRolesToTag(
@@ -65,32 +67,34 @@ async function sendEmbed(mainObject, channel, requiredCompositionList) {
                 mainObject,
                 groupUtilityCollector
             );
+        } else if (i.customId === "cancelGroup") {
+            if (discordUserId !== interactionUserId) {
+                await i.reply({
+                    content: "Only the group leader can cancel the group!",
+                    ephemeral: true,
+                });
+                return;
+            }
+            groupUtilityCollector.stop("cancelledAfterCreation");
         }
     });
 
     groupUtilityCollector.on("end", async (collected, reason) => {
         if (reason === "time") {
-            const timedOutObject = {
-                title: "LFG TIMED OUT (30 mins) ⏰",
-                color: 0x3c424b,
-            };
-
             try {
-                await sentEmbed.edit({
-                    content: "",
-                    embeds: [timedOutObject],
-                    components: [],
-                });
-
+                await createStatusEmbed(
+                    "Group creation timed out! (30 mins have passed without a full group forming)",
+                    sentEmbed
+                );
                 // Update the interaction status to "timed out"
                 await interactionStatusTable.update(
-                    { interaction_status: "timed out" },
+                    { interaction_status: "timeoutAfterCreation" },
                     { where: { interaction_id: mainObject.interactionId } }
                 );
-            } catch (err) {
-                console.error("Error editing message:", err);
+            } catch (e) {
+                processEmbedError(e, "Group creation timeout error", interactionUserId);
             }
-        } else if (reason === "full") {
+        } else if (reason === "finished") {
             // Send the finished dungeon data to the database
             try {
                 await dungeonInstanceTable.create({
@@ -105,13 +109,26 @@ async function sendEmbed(mainObject, channel, requiredCompositionList) {
                     dps3: mainObject.roles.DPS.spots[2],
                 });
 
-                // Update the interaction status to "finished"
+                // Update the interaction status to "finished" in the database
                 await interactionStatusTable.update(
                     { interaction_status: "finished" },
                     { where: { interaction_id: mainObject.interactionId } }
                 );
-            } catch (err) {
-                console.error("Error writing to table:", err);
+            } catch (e) {
+                processEmbedError(e, "Finished processing error", interactionUserId);
+            }
+        } else if (reason === "cancelledAfterCreation") {
+            // Update the embed to reflect the cancellation
+            try {
+                await createStatusEmbed("LFG cancelled by group creator.", sentEmbed);
+
+                // Update the interaction status to "cancelled" in the database
+                await interactionStatusTable.update(
+                    { interaction_status: "cancelledAfterCreation" },
+                    { where: { interaction_id: mainObject.interactionId } }
+                );
+            } catch (e) {
+                processEmbedError(e, "Cancelled after creation error", interactionUserId);
             }
         }
     });

--- a/utils/sendEmbed.js
+++ b/utils/sendEmbed.js
@@ -1,10 +1,5 @@
 const { ComponentType } = require("discord.js");
-const {
-    parseRolesToTag,
-    generateListedAsString,
-    addUserToRole,
-    userExistsInAnyRole,
-} = require("./utilFunctions");
+const { parseRolesToTag, generateListedAsString, addUserToRole, userExistsInAnyRole } = require("./utilFunctions");
 const { dungeonInstanceTable, interactionStatusTable } = require("./loadDb");
 const { processDungeonEmbed, getDungeonObject, getDungeonButtonRow } = require("./dungeonLogic");
 const { processEmbedError, createStatusEmbed } = require("./errorHandling");
@@ -14,11 +9,7 @@ async function sendEmbed(mainObject, channel, requiredCompositionList) {
     const interactionUserId = mainObject.interactionUser.userId;
 
     // Get the roles to tag
-    const rolesToTag = parseRolesToTag(
-        dungeonDifficulty,
-        requiredCompositionList,
-        channel.guild.id
-    );
+    const rolesToTag = parseRolesToTag(dungeonDifficulty, requiredCompositionList, channel.guild.id);
 
     // Update the listedAs field in the mainObject
     mainObject.embedData.listedAs = generateListedAsString(dungeonName, dungeonDifficulty);
@@ -44,34 +35,13 @@ async function sendEmbed(mainObject, channel, requiredCompositionList) {
         const discordUserId = `<@${i.user.id}>`;
         if (i.customId === "Tank") {
             addUserToRole(discordUserId, mainObject, "Tank");
-            await processDungeonEmbed(
-                i,
-                rolesToTag,
-                dungeonName,
-                dungeonDifficulty,
-                mainObject,
-                groupUtilityCollector
-            );
+            await processDungeonEmbed(i, rolesToTag, dungeonName, dungeonDifficulty, mainObject, groupUtilityCollector);
         } else if (i.customId === "Healer") {
             addUserToRole(discordUserId, mainObject, "Healer");
-            await processDungeonEmbed(
-                i,
-                rolesToTag,
-                dungeonName,
-                dungeonDifficulty,
-                mainObject,
-                groupUtilityCollector
-            );
+            await processDungeonEmbed(i, rolesToTag, dungeonName, dungeonDifficulty, mainObject, groupUtilityCollector);
         } else if (i.customId === "DPS") {
             addUserToRole(discordUserId, mainObject, "DPS");
-            await processDungeonEmbed(
-                i,
-                rolesToTag,
-                dungeonName,
-                dungeonDifficulty,
-                mainObject,
-                groupUtilityCollector
-            );
+            await processDungeonEmbed(i, rolesToTag, dungeonName, dungeonDifficulty, mainObject, groupUtilityCollector);
         } else if (i.customId === "getPassphrase") {
             // Confirm the user is in the group
             if (!userExistsInAnyRole(discordUserId, mainObject, "getPassphrase")) {
@@ -81,7 +51,7 @@ async function sendEmbed(mainObject, channel, requiredCompositionList) {
                 });
             } else {
                 await i.reply({
-                    content: `The passphrase for the dungeon is: ${mainObject.utils.passphrase.phrase}`,
+                    content: `The passphrase for the dungeon is: ${mainObject.utils.passphrase.phrase}\nAdd this to your note when applying to the group in-game!`,
                     ephemeral: true,
                 });
             }

--- a/utils/utilFunctions.js
+++ b/utils/utilFunctions.js
@@ -106,13 +106,6 @@ function addUserToRole(userId, mainObject, newRole) {
     }
 }
 
-async function sendPassphraseToUser(i, mainObject) {
-    await i.reply({
-        content: `The passphrase for the dungeon is: ${mainObject.utils.passphrase.phrase}`,
-        ephemeral: true,
-    });
-}
-
 module.exports = {
     generateRoleIcons,
     generateListedAsString,
@@ -121,5 +114,4 @@ module.exports = {
     parseRolesToTag,
     userExistsInAnyRole,
     addUserToRole,
-    sendPassphraseToUser,
 };


### PR DESCRIPTION
This pull changes the dynamics of the how the required composition select menu works & also how the passphrase is displayed to the user.

We're adding a button to confirm required composition so that the user doesn't accidentally click off the menu and then have to start over.

The passphrase is now being set hidden and only available to members that commit to a role and sign up to the dungeon. This way, we avoid anyone not signed up knowing the passphrase and applying in-game and then someone who signs up doesn't get a spot. This will make it exclusive to NoP members.