### PR TITLE
fix: Update key level labels in LFG stats and utility functions to reflect correct ranges

### DIFF
--- a/commands/utility/lfgstats.js
+++ b/commands/utility/lfgstats.js
@@ -46,7 +46,7 @@ module.exports = {
                 new StringSelectMenuOptionBuilder().setLabel("M2-M3").setValue("key_levels_two"),
                 new StringSelectMenuOptionBuilder().setLabel("M4-M6").setValue("key_levels_three"),
                 new StringSelectMenuOptionBuilder().setLabel("M7-M9").setValue("key_levels_four"),
-                new StringSelectMenuOptionBuilder().setLabel("M10").setValue("key_levels_five")
+                new StringSelectMenuOptionBuilder().setLabel("M10-M11").setValue("key_levels_five")
             );
 
         const getKeyLevelRow = new ActionRowBuilder().addComponents(selectKeyLevelRow);
@@ -62,7 +62,7 @@ module.exports = {
             key_levels_two: "M2-M3",
             key_levels_three: "M4-M6",
             key_levels_four: "M7-M9",
-            key_levels_five: "M10",
+            key_levels_five: "M10-M11",
         };
 
         const userFilter = (i) => i.user.id === interaction.user.id;

--- a/utils/utilFunctions.js
+++ b/utils/utilFunctions.js
@@ -111,7 +111,7 @@ function parseRolesToTag(difficulty, requiredComposition, guildId) {
     } else if (difficulty < 10) {
         roleDifficultyString = "-M7-9";
     } else {
-        roleDifficultyString = "-M10";
+        roleDifficultyString = "-M10-11";
     }
 
     const globalRoles = global.roleMap.get(guildId);


### PR DESCRIPTION
This addresses the following issue:
![image](https://github.com/user-attachments/assets/8606ccf6-c9e7-496c-92bc-acbec52bf3e0)
